### PR TITLE
Improve project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,8 @@ $ git clone --recursive git@github.com:input-output-hk/icarus-poc.git
 $ git submodule update --init --recursive git@github.com:input-output-hk/icarus-poc.git
 
 # Install dependencies
-$ npm install
+$ npm run setup
 
-# Generate and copy into node_modules the rust-cardano-crypto module
-$ chmod +x ./init-rust-cardano-crypto-node-module.sh 
-$ ./init-rust-cardano-crypto-node-module.sh 
 ```
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Icarus light Cardano wallet - PoC",
   "scripts": {
+    "setup": "./setup-environment.sh",
     "dev": "node scripts/dev",
     "build": "node scripts/build",
     "compress": "node scripts/compress",

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+npm install;
 cd rust-cardano-crypto;
 npm install;
 ./build;


### PR DESCRIPTION
Now before run the project you should execute: `npm run setup` This replace `npm install` and installation of the rust module.