### PR TITLE
Amounts Fix

### DIFF
--- a/app/api/ExplorerApi.js
+++ b/app/api/ExplorerApi.js
@@ -10,9 +10,17 @@ ExplorerApi.config = {
 const toTx = address => async function (response) {
   const parsedTxs = response.Right;
   parsedTxs.caTxList = parsedTxs.caTxList.map((tx) => {
-    //FIXME: this is not completely true. If it sent fund to itself this won't work
+    //FIXME: This a simplification:
+    // -- This won't work if send funds to itself
+    // -- If no change is sent
+    const foundInput = tx.ctbInputs.find(input => input[0] === address);
+    const foundOutput = tx.ctbOutputs.find(output => output[0] === address);
+    const isOutgoing = foundInput !== undefined;
+    const change = foundOutput !== undefined && isOutgoing ? foundOutput[1].getCoin : 0;
+    const amount = isOutgoing ? tx.ctbOutputSum.getCoin - change : foundOutput[1].getCoin;
     return Object.assign({}, tx, {
-      isOutgoing: tx.ctbInputs.findIndex(input => input[0] === address) !== -1
+      isOutgoing,
+      amount
     });
   });
   return parsedTxs;

--- a/app/components/AdaAmount.js
+++ b/app/components/AdaAmount.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import NumberFormat from 'react-number-format';
+
+const AdaAmount = ({ amount, showSuffix = true }) => {
+  const suffix = showSuffix ? ' ADA' : '';
+  return (
+    <NumberFormat
+      thousandSeparator
+      value={Number(amount) / 1000000}
+      fixedDecimalScale
+      decimalScale="6"
+      displayType="text"
+      suffix={suffix}
+    />
+  );
+};
+
+export default AdaAmount;

--- a/app/components/WalletHistory.js
+++ b/app/components/WalletHistory.js
@@ -6,7 +6,6 @@ import List, {
 } from 'material-ui/List';
 import Typography from 'material-ui/Typography';
 import Avatar from 'material-ui/Avatar';
-import NumberFormat from 'react-number-format';
 import OpenInNew from 'material-ui-icons/OpenInNew';
 import IconButton from 'material-ui/IconButton';
 import ExpansionPanel, {
@@ -19,6 +18,7 @@ import {
   formatTimestamp,
   formatRawTimestamp
 } from '../utils/formatter';
+import AdaAmount from '../components/AdaAmount';
 import style from './WalletHistory.css';
 
 class WalletHistory extends Component {
@@ -27,10 +27,6 @@ class WalletHistory extends Component {
     super();
     this.state = {};
   }
-
-  getAmount = ({ ctbOutputSum: { getCoin } }) => {
-    return Number(getCoin) / 1000000;
-  };
 
   getSendReceivIconPath = (tx) => {
     return tx.isOutgoing ? 'img/send-ic.svg' : 'img/receive-ic.svg';
@@ -50,7 +46,7 @@ class WalletHistory extends Component {
           <div className={style.amount}>
             <div>
               <Typography variant="subheading">
-                <NumberFormat thousandSeparator value={this.getAmount(tx)} displayType="text" suffix=" ADA" />
+                <AdaAmount amount={tx.amount} />
               </Typography>
             </div>
             <div>
@@ -65,7 +61,10 @@ class WalletHistory extends Component {
             <IconButton onClick={() => openTx(tx.ctbId)}><OpenInNew color="disabled" style={{ fontSize: 20 }} /></IconButton>
           </div>
           <Typography variant="subheading">Timestamp</Typography>
-          <Typography variant="body2" color="textSecondary">{formatRawTimestamp(tx.ctbTimeIssued)}
+          <Typography variant="body2" color="textSecondary">{formatRawTimestamp(tx.ctbTimeIssued)}</Typography>
+          <Typography variant="subheading">Fee</Typography>
+          <Typography variant="body2" color="textSecondary">
+            <AdaAmount amount={tx.ctbInputSum.getCoin - tx.ctbOutputSum.getCoin} />
           </Typography>
         </ExpansionPanelDetails>
       </ExpansionPanel>

--- a/app/containers/Wallet.js
+++ b/app/containers/Wallet.js
@@ -6,7 +6,7 @@ import Typography from 'material-ui/Typography';
 import OpenInNew from 'material-ui-icons/OpenInNew';
 import IconButton from 'material-ui/IconButton';
 import Avatar from 'material-ui/Avatar';
-import NumberFormat from 'react-number-format';
+import AdaAmount from '../components/AdaAmount';
 import WalletHistory from '../components/WalletHistory';
 import SendAdaForm from '../components/SendAdaForm';
 import { CircularProgress } from 'material-ui/Progress';
@@ -115,10 +115,7 @@ class Wallet extends Component {
         <div className={style.headerContent}>
           <div className={style.header}>
             <Typography variant="display2" color="inherit">
-              {!this.state.loading ?
-                (<NumberFormat thousandSeparator value={this.state.balance} displayType="text" />) :
-                '...'
-              }
+              { !this.state.loading ? (<AdaAmount amount={this.state.balance} showSuffix={false} />) : '...' }
             </Typography>
             {!this.state.loading && <Avatar className={style.symbol} src="img/ada-symbol-smallest-white.inline.svg" /> }
           </div>


### PR DESCRIPTION
This Commit includes 3 changes:
- Amounts are now displayed as they are supposed to. ADA / 1,000,000
with 6 decimals
- Amount displayed when listing tx history is correct
- Fee is displayed in expanded TX history