### PR TITLE
[PI-61] Properly set ctCondition

### DIFF
--- a/app/api/ada/ada-methods.js
+++ b/app/api/ada/ada-methods.js
@@ -208,11 +208,12 @@ function mapTransactions(
 ): Array<AdaTransaction> {
   return transactions.map(tx => {
     const { isOutgoing, amount } = spenderData(tx, accountAddress);
+    const isPending = tx.ctsBlockHeight == null;
     return {
       ctAmount: {
         getCCoin: amount
       },
-      ctConfirmations: latestBlockNumber - tx.ctsBlockHeight,
+      ctConfirmations: isPending ? 0 : latestBlockNumber - tx.ctsBlockHeight,
       ctId: tx.ctsId,
       ctInputs: tx.ctsInputs.map(mapInputOutput),
       ctIsOutgoing: isOutgoing,
@@ -222,7 +223,7 @@ function mapTransactions(
         ctmTitle: undefined
       },
       ctOutputs: tx.ctsOutputs.map(mapInputOutput),
-      ctCondition: 'CPtxInBlocks' // FIXME: What's this?
+      ctCondition: isPending ? 'CPtxApplying' : 'CPtxInBlocks'
     };
   });
 }


### PR DESCRIPTION
## Description

Properly sets the current `ctCondtion` for the txs. 

_Note:_ [`tx.ctsBlockHeight` is set to `null` if the tx is in the tx pool](https://github.com/atixlabs/cardano-sl/blob/develop/explorer/src/Pos/Explorer/Web/Server.hs#L465)