### PR TITLE
[PI-135] Confirmation level is not properly shown

### DIFF
--- a/app/api/ada/ada-methods.js
+++ b/app/api/ada/ada-methods.js
@@ -48,6 +48,7 @@ const WALLET_KEY = 'WALLET'; // single wallet atm
 const WALLET_SEED_KEY = 'SEED';
 const ADDRESSES_KEY = 'ADDRESSES'; // we store a single Map<Address, AdaAddress>
 const TX_KEY = 'TXS'; // single txs list atm
+const LAST_BLOCK_NUMBER_KEY = 'LAST_BLOCK_NUMBER'; // stores de last block number
 
 export type AdaWalletParams = {
   walletPassword: ?string,
@@ -191,6 +192,10 @@ export function getWalletSeed() {
   return getFromStorage(WALLET_SEED_KEY);
 }
 
+export function getLastBlockNumber() {
+  return getFromStorage(LAST_BLOCK_NUMBER_KEY);
+}
+
 /**
  * Temporary method helpers
  */
@@ -246,11 +251,14 @@ function mapTransactions(
     const outputs = mapInputOutput(tx.outputs_address, tx.outputs_amount);
     const { isOutgoing, amount } = spenderData(inputs, outputs, accountAddresses);
     const isPending = tx.block_num === null;
+    if (!getLastBlockNumber() || tx.best_block_num > getLastBlockNumber()) {
+      saveInStorage(LAST_BLOCK_NUMBER_KEY, tx.best_block_num);
+    }
     return {
       ctAmount: {
         getCCoin: amount
       },
-      ctConfirmations: tx.best_block_num - tx.block_num,
+      ctBlockNumber: tx.block_num,
       ctId: tx.hash,
       ctInputs: inputs,
       ctIsOutgoing: isOutgoing,

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -23,7 +23,8 @@ import {
   newAdaAddress,
   getWalletSeed,
   getSingleCryptoAccount,
-  getAdaAddresses
+  getAdaAddresses,
+  getLastBlockNumber
 } from './ada-methods';
 
 import type {
@@ -797,7 +798,6 @@ const _conditionToTxState = (condition: string) => {
       return 'failed';
     default:
       return 'ok'; // CPtxInBlocks && CPtxNotTracked
-  }
 };
 
 const _createTransactionFromServerData = action(
@@ -816,7 +816,7 @@ const _createTransactionFromServerData = action(
       ),
       date: new Date(ctmDate),
       description: ctmDescription || '',
-      numberOfConfirmations: data.ctConfirmations,
+      numberOfConfirmations: getLastBlockNumber() - data.ctBlockNumber,
       addresses: {
         from: data.ctInputs.map(address => address[0]),
         to: data.ctOutputs.map(address => address[0])

--- a/app/api/ada/lib/utils.js
+++ b/app/api/ada/lib/utils.js
@@ -1,5 +1,3 @@
-const bs58 = require('bs58');
-
 // @flow
 import bs58 from 'bs58';
 

--- a/app/api/ada/types.js
+++ b/app/api/ada/types.js
@@ -59,7 +59,7 @@ export type AdaAccounts = Array<AdaAccount>;
 
 export type AdaTransaction = {
   ctAmount: AdaAmount,
-  ctConfirmations: number,
+  ctBlockNumber: number,
   ctId: string,
   ctInputs: AdaTransactionInputOutput,
   ctIsOutgoing: boolean,


### PR DESCRIPTION
Both number of confirmations and status are calculated for all transactions, including the old ones, based on the last block number saved in local storage and the block number of the transaction