### PR TITLE
[PI-220] Update last block only with confirmed txs

### DIFF
--- a/app/api/ada/adaTransactions/adaTransactionsHistory.js
+++ b/app/api/ada/adaTransactions/adaTransactionsHistory.js
@@ -100,7 +100,8 @@ async function _updateAdaTxsHistoryForGroupOfAddresses(
   if (history.length > 0) {
     // FIXME: Add an endpoint for querying the best_block_num
     // Update last block, done for one tx as all the best_block_num of a request are the same
-    if (!getLastBlockNumber() || history[0].best_block_num > getLastBlockNumber()) {
+    const lastKnownBlockNumber = getLastBlockNumber();
+    if (!lastKnownBlockNumber || history[0].best_block_num > lastKnownBlockNumber) {
       saveLastBlockNumber(history[0].best_block_num);
     }
 


### PR DESCRIPTION
## Description

Updates last block (from local storage) only when processing confirmed txs. Also changed it to do it once per request as all txs from a request will have the same `best_block_num`.

This fixes the issue that if a wallet has pending txs when restoring, it set that value to `ptx.best_block_num` (`"undefined"`), causing the wallet to crash.