### PR TITLE
Fix autocomplete background in modal dialogs

### DIFF
--- a/app/themes/simple/SimpleModal.scss
+++ b/app/themes/simple/SimpleModal.scss
@@ -27,7 +27,7 @@
 
     .SimpleInput_input,
     .SimpleAutocomplete_autocompleteContent {
-      background-color: transparent;
+      background-color: transparent !important;
     }
   }
 }


### PR DESCRIPTION
This PR fixes background color of Autocomplete component within Restore Wallet dialog.
Background was grey and it should be transparent/white.

![screen shot 2018-06-27 at 10 14 23](https://user-images.githubusercontent.com/376611/41961522-fadcbf1c-79f2-11e8-848b-7dd0344e4967.png)
