### PR TITLE
[PI-322] Fix in broken style in error and waiting page in daedalus transfer

### DIFF
--- a/app/components/layout/SidebarLayout.scss
+++ b/app/components/layout/SidebarLayout.scss
@@ -32,6 +32,7 @@ $topBarHeight: 64px;
 }
 
 .contentWrapper {
+  height: 100%;
   overflow-x: hidden;
   overflow-y: overlay;
   position: relative;


### PR DESCRIPTION
## This PR solve this issue:
[PI-322 - Broken style in error and waiting Daedalus transfer pages](https://iohk.myjetbrains.com/youtrack/agiles/100-108/101-642?issue=PI-322)

- Waiting page before the change:

![daedalustransferwaiting_before](https://user-images.githubusercontent.com/39060878/43602011-18c59a9c-9665-11e8-8ef4-4cd681c57414.png)

- Waiting page after the change:

![daedalustransferwaiting_after](https://user-images.githubusercontent.com/39060878/43602013-1bf6aed6-9665-11e8-8331-89d591e3752a.png)


- Error page before the change:

![daedalustransfererror_before](https://user-images.githubusercontent.com/39060878/43602177-949f4938-9665-11e8-9ee0-252238e50ed2.png)

- Error page after the change:

![daedalustransfererror_after](https://user-images.githubusercontent.com/39060878/43602182-975ff8d4-9665-11e8-999a-88a9d2dec10f.png)
