### PR TITLE
[PI-326] Fix in copied address notification message styles

### DIFF
--- a/app/components/widgets/NotificationMessage.scss
+++ b/app/components/widgets/NotificationMessage.scss
@@ -1,14 +1,11 @@
 .component {
   background-color: var(--theme-notification-message-background-color);
-  bottom: 0;
   height: 0;
-  left: 50%;
-  margin-left: -200px;
   overflow: hidden;
   position: absolute;
   text-align: center;
   transition: all 200ms linear;
-  width: 400px;
+  width: 100%;
 }
 
 .show {


### PR DESCRIPTION
https://iohk.myjetbrains.com/youtrack/agiles/100-108/101-642?issue=PI-326

Before the fix:

![addresscopymsg](https://user-images.githubusercontent.com/39060878/43723197-6e3b7388-996d-11e8-9d07-3b1ce93bf108.png)

After the fix:

![addresscopymsg_after](https://user-images.githubusercontent.com/39060878/43723203-7259956c-996d-11e8-9e3f-994de47ac052.png)
