### PR TITLE
Port fix back to Icarus

### DIFF
--- a/app/stores/ada/DaedalusTransferStore.js
+++ b/app/stores/ada/DaedalusTransferStore.js
@@ -91,6 +91,10 @@ export default class DaedalusTransferStore extends Store {
     */
     this.ws.addEventListener('message', async (event: any) => {
       try {
+        // Note: we only expect a single message from our WS so we can close it right away.
+        // Not closing it right away will cause a WS timeout error as we don't keep the connection alive.
+        this.ws.close(WS_CODE_NORMAL_CLOSURE);
+
         const data = JSON.parse(event.data);
         Logger.info(`[ws::message] on: ${data.msg}`);
         if (data.msg === MSG_TYPE_RESTORE) {
@@ -119,14 +123,20 @@ export default class DaedalusTransferStore extends Store {
     });
 
     this.ws.addEventListener('close', (event: any) => {
-      Logger.info(
-        `[ws::close] CODE: ${event.code} - REASON: ${event.reason} - was clean? ${event.wasClean}`
-      );
       if (event.code !== WS_CODE_NORMAL_CLOSURE) {
+        // if connection was not closed normally, we log this as an error. Otherwise it's an info
+        Logger.error(
+          `[ws::close] CODE: ${event.code} - REASON: ${event.reason} - was clean? ${event.wasClean}`
+        );
+
         runInAction(() => {
           this.status = 'error';
           this.error = new WebSocketRestoreError();
         });
+      } else {
+        Logger.info(
+          `[ws::close] CODE: ${event.code} - REASON: ${event.reason} - was clean? ${event.wasClean}`
+        );
       }
     });
   }


### PR DESCRIPTION
Description of the bug:

When a user tried to migrate their Daedalus wallet to Yoroi, we need some time to process the transfer through a WebSocket to the Yoroi-backend. The socket automatically times out if it hasn't been used for a certain amount of time (no keep-alive) causing the migration to appear to have failed with the error `Unable to restore Daedalus wallet.
Error while restoring blockchain addresses.` if the user doesn't finish the migration process 50 seconds from when they started it (regardless of whether or not migration was successful). Additionally, no error logs were generated.

This PR adds two fixes

1) Properly generate an error log if the WS closed unexpectedly
2) Once we receive the transaction data from the WS, close the connection "normally"

Tested on Staging